### PR TITLE
correction for upload of json files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,9 @@
+//dummy trigger of commit
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'com.github.johnrengelman.shadow'
-
+//another dummy trigger of commit
 group            = 'com.nexosis'
 archivesBaseName = 'nexosisclient-java'
 version          = '4.0.1'

--- a/src/main/java/com/nexosis/model/DataSetStreamSource.java
+++ b/src/main/java/com/nexosis/model/DataSetStreamSource.java
@@ -49,10 +49,6 @@ public class DataSetStreamSource implements IDataSetSource {
         if (!contentType.equalsIgnoreCase("text/csv") && !contentType.startsWith("application/json")) {
             throw new IllegalArgumentException("contentType must be set to text/csv or application/json");
         }
-        // force to use application/json w/ utf-8
-        if (contentType.equalsIgnoreCase("application/json")) {
-            contentType = Json.MEDIA_TYPE;
-        }
 
         this.contentType = contentType;
     }


### PR DESCRIPTION
There is another issue with uploading DataSets related to contentType. This time, when i tired to create DataSet from JSON file (borrowed subset of cardio.json) i got same contentType problem as for csv.

The cause is adding hardcoding "application/json; charset=UTF-8" every time user sets contentType of DataSetStreamSource to "application/json"

I simply removed this override and Im able to create json dataset.